### PR TITLE
feat: catch and log deferreds' error

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,23 @@ There are also two decorators, `defer.onSuccess()` and
 `defer.onFailure()` which run the deferreds only, respectively, in
 case of success or in case of failure.
 
+### On report
+
+Exceptions (or rejected promises) thrown in deferred are caught and
+printed on the console.
+
+This can be customized with the `onError()` method:
+
+```js
+const myDefer = defer.onError(error => {
+  log(error)
+})
+
+const fn = myDefer(($defer, arg1, arg2) => {
+  // ...
+})
+```
+
 ## Development
 
 ```

--- a/src/index.spec.js
+++ b/src/index.spec.js
@@ -77,4 +77,40 @@ describe('defer()', () => {
       expect(i).toBe(0)
     })
   })
+
+  it('should log exceptions from deferreds', () => {
+    const e1 = new Error('e1')
+    const e2 = new Error('e2')
+    const onError = jest.fn()
+    const fn = defer.onError(onError)($defer => {
+      $defer(() => { throw e1 })
+      $defer(() => { throw e2 })
+    })
+
+    fn()
+
+    expect(onError.mock.calls).toEqual([
+      [ e2 ],
+      [ e1 ]
+    ])
+  })
+
+  it('should log exceptions/rejections from deferreds', () => {
+    const e1 = new Error('e1')
+    const e2 = new Error('e2')
+    const onError = jest.fn()
+    const fn = defer.onError(onError)($defer => {
+      $defer(() => { throw e1 })
+      $defer(() => Promise.reject(e2))
+
+      return Promise.resolve()
+    })
+
+    return fn().then(() => {
+      expect(onError.mock.calls).toEqual([
+        [ e2 ],
+        [ e1 ]
+      ])
+    })
+  })
 })


### PR DESCRIPTION
This can be customized with `onError()` method.

Fixes #9