### PR TITLE
feat: use $defer.call() to pass callback context

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,9 +23,9 @@ Installation of the [npm package](https://npmjs.org/package/golike-defer):
 ## Usage
 
 - `$defer(cb)`: `cb` will be called at the end of the function
-- `$defer(thisArg, cb)`: `cb` will be called with the context `thisArg` (cannot be a function)
 - `$defer(cb, arg1, arg2)`: `cb` will be called with `arg1` and `arg2` arguments
-- `$defer(thisArg, 'method')`: `thisArg.method` will be called at the end of the function
+- `$defer.call(thisArg, cb)`: `cb` will be called with the context `thisArg`
+- `$defer.call(thisArg, 'method')`: `thisArg.method` will be called at the end of the function
 
 ```js
 import defer from 'golike-defer'

--- a/src/index.js
+++ b/src/index.js
@@ -57,23 +57,18 @@ const makeDefer = (onSuccess, onFailure) => {
     const deferreds = []
 
     const args = [ function (deferred) {
-      let argsStart = 1
-      let thisArg, args
+      let args
       if (typeof deferred !== 'function') {
-        thisArg = deferred
-        deferred = arguments[argsStart++]
-        if (typeof deferred !== 'function') {
-          deferred = thisArg[deferred]
-        }
+        deferred = this[deferred]
       }
-      const nArgs = arguments.length - argsStart
+      const nArgs = arguments.length - 1
       if (nArgs !== 0) {
         args = new Array(nArgs)
         for (let i = 0; i < nArgs; ++i) {
-          args[i] = arguments[i + argsStart]
+          args[i] = arguments[i + 1]
         }
       }
-      deferreds.push(new Deferred(deferred, thisArg, args))
+      deferreds.push(new Deferred(deferred, this, args))
     } ]
     push.apply(args, arguments)
     const result = tryCatch(fn, this, args)

--- a/src/index.spec.js
+++ b/src/index.spec.js
@@ -117,7 +117,7 @@ describe('defer()', () => {
   it('accepts optional context and arguments', () => {
     const deferred = jest.fn()
     defer($defer => {
-      $defer('foo', deferred, 'bar', 'baz')
+      $defer.call('foo', deferred, 'bar', 'baz')
     })()
     expect(deferred.mock.instances).toEqual([ 'foo' ])
     expect(deferred.mock.calls).toEqual([ [ 'bar', 'baz' ] ])
@@ -127,7 +127,7 @@ describe('defer()', () => {
     const foo = jest.fn()
     const obj = { foo }
     defer($defer => {
-      $defer(obj, 'foo', 'bar', 'baz')
+      $defer.call(obj, 'foo', 'bar', 'baz')
     })()
     expect(foo.mock.instances).toEqual([ obj ])
     expect(foo.mock.calls).toEqual([ [ 'bar', 'baz' ] ])


### PR DESCRIPTION
This is a BREAKING CHANGE.

I think it's cleaner than using a magic first argument.